### PR TITLE
API Create Marker

### DIFF
--- a/jukebox_radio/streams/urls.py
+++ b/jukebox_radio/streams/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path
 
+from jukebox_radio.streams.views.marker import (
+    MarkerCreateView,
+)
 from jukebox_radio.streams.views.stream import (
     StreamGetView,
     StreamInitializeView,
@@ -19,6 +22,13 @@ from jukebox_radio.streams.views.queue import (
 
 app_name = "streams"
 urlpatterns = [
+    # Marker
+    # --------------------------------------------------------------------------
+    path(
+        "marker/create/",
+        view=MarkerCreateView.as_view(),
+        name="marker-create",
+    ),
     # Stream
     # --------------------------------------------------------------------------
     path(

--- a/jukebox_radio/streams/views/marker/__init__.py
+++ b/jukebox_radio/streams/views/marker/__init__.py
@@ -1,0 +1,1 @@
+from .create_view import MarkerCreateView

--- a/jukebox_radio/streams/views/marker/create_view.py
+++ b/jukebox_radio/streams/views/marker/create_view.py
@@ -1,0 +1,23 @@
+from django.apps import apps
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from jukebox_radio.core.base_view import BaseView
+
+
+class MarkerCreateView(BaseView, LoginRequiredMixin):
+    def post(self, request, **kwargs):
+        """
+        When a user adds something to the queue.
+        """
+        Marker = apps.get_model("streams", "Marker")
+
+        track_uuid = request.POST.get("trackUuid")
+        timestamp_ms = request.POST.get("timestampMilliseconds")
+
+        marker = Marker.objects.create(
+            user=request.user,
+            track_id=track_uuid,
+            timestamp_ms=timestamp_ms,
+        )
+
+        return self.http_response_200()


### PR DESCRIPTION
**Previous PR**

https://github.com/0x213F/jukebox-radio-django/pull/5

**Next PR**

https://github.com/0x213F/jukebox-radio-django/pull/7

**Summary**

These 6 PRs implement the backend changes required for advanced queue playback functionality.

This new endpoint allows a user to create a marker.