### PR TITLE
API endpoint for deleting a marker

### DIFF
--- a/jukebox_radio/streams/models/marker_model.py
+++ b/jukebox_radio/streams/models/marker_model.py
@@ -4,6 +4,8 @@ from django.db import models
 
 import pgtrigger
 
+from jukebox_radio.core import time as time_util
+
 
 @pgtrigger.register(
     pgtrigger.Protect(
@@ -32,3 +34,7 @@ class Marker(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     deleted_at = models.DateTimeField(null=True, blank=True)
+
+    def archive(self):
+        self.deleted_at = time_util.now()
+        self.save()

--- a/jukebox_radio/streams/urls.py
+++ b/jukebox_radio/streams/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from jukebox_radio.streams.views.marker import (
     MarkerCreateView,
+    MarkerDeleteView,
 )
 from jukebox_radio.streams.views.stream import (
     StreamGetView,
@@ -28,6 +29,11 @@ urlpatterns = [
         "marker/create/",
         view=MarkerCreateView.as_view(),
         name="marker-create",
+    ),
+    path(
+        "marker/delete/",
+        view=MarkerDeleteView.as_view(),
+        name="marker-delete",
     ),
     # Stream
     # --------------------------------------------------------------------------

--- a/jukebox_radio/streams/views/marker/__init__.py
+++ b/jukebox_radio/streams/views/marker/__init__.py
@@ -1,1 +1,2 @@
 from .create_view import MarkerCreateView
+from .delete_view import MarkerDeleteView

--- a/jukebox_radio/streams/views/marker/create_view.py
+++ b/jukebox_radio/streams/views/marker/create_view.py
@@ -7,7 +7,7 @@ from jukebox_radio.core.base_view import BaseView
 class MarkerCreateView(BaseView, LoginRequiredMixin):
     def post(self, request, **kwargs):
         """
-        When a user adds something to the queue.
+        Create a Marker.
         """
         Marker = apps.get_model("streams", "Marker")
 

--- a/jukebox_radio/streams/views/marker/delete_view.py
+++ b/jukebox_radio/streams/views/marker/delete_view.py
@@ -1,0 +1,19 @@
+from django.apps import apps
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from jukebox_radio.core.base_view import BaseView
+
+
+class MarkerDeleteView(BaseView, LoginRequiredMixin):
+    def post(self, request, **kwargs):
+        """
+        Delete (archive) a Marker.
+        """
+        Marker = apps.get_model("streams", "Marker")
+
+        marker_uuid = request.POST.get("markerUuid")
+
+        marker = Marker.objects.get(uuid=marker_uuid)
+        marker.archive()
+
+        return self.http_response_200()


### PR DESCRIPTION
**Previous PR**

https://github.com/0x213F/jukebox-radio-django/pull/6

**Next PR**

https://github.com/0x213F/jukebox-radio-django/pull/8

**Summary**

These 6 PRs implement the backend changes required for advanced queue playback functionality.

This new endpoint allows a user to delete a marker.