### PR TITLE
API Create Interval

### DIFF
--- a/jukebox_radio/streams/models/queue_interval_model.py
+++ b/jukebox_radio/streams/models/queue_interval_model.py
@@ -1,8 +1,90 @@
 import uuid
 
+from django.apps import apps
 from django.db import models
+from django.db.models import Q
 
 import pgtrigger
+
+
+class QueueIntervalManager(models.Manager):
+    def serialize(self, queue_interval):
+        return {}
+
+    def create_queue_interval(
+        self, *, user, queue_id, lower_bound_id, upper_bound_id, is_muted,
+        repeat_count,
+    ):
+        QueueInterval = apps.get_model('streams', 'QueueInterval')
+
+        if not lower_bound_id and not upper_bound_id:
+            raise ValueError("Either lower or upper must be specified")
+
+        lowest_bound = QueueInterval.objects.lowest_bound(queue_id)
+        if not lower_bound_id and lowest_bound.exists():
+            raise ValueError("A conflicting QueueInterval already exists")
+
+        highest_bound = QueueInterval.objects.highest_bound(queue_id)
+        if not upper_bound_id and highest_bound.exists():
+            raise ValueError("A conflicting QueueInterval already exists")
+
+        if lower_bound_id and upper_bound_id:
+            conflicting_interval = (
+                QueueInterval
+                .objects
+                .conflicting_interval(
+                    queue_id=queue_id,
+                    lower_bound_id=lower_bound_id,
+                    upper_bound_id=upper_bound_id,
+                )
+            )
+            if conflicting_interval.exists():
+                raise ValueError("A conflicting QueueInterval already exists")
+
+        return QueueInterval.objects.create(
+            user=user,
+            queue_id=queue_id,
+            lower_bound_id=lower_bound_id,
+            upper_bound_id=upper_bound_id,
+            is_muted=is_muted,
+            repeat_count=repeat_count,
+        )
+
+
+
+class QueueIntervalQuerySet(models.QuerySet):
+    def lowest_bound(self, queue_id):
+        return self.filter(
+            queue_id=queue_id,
+            lower_bound__isnull=True,
+        )
+
+    def highest_bound(self, queue_id):
+        return self.filter(
+            queue_id=queue_id,
+            upper_bound__isnull=True,
+        )
+
+    def conflicting_interval(self, *, queue_id, lower_bound_id, upper_bound_id):
+        Marker = apps.get_model('streams', 'Marker')
+
+        lower_bound = Marker.objects.get(uuid=lower_bound_id, queue_id=queue_id)
+        upper_bound = Marker.objects.get(uuid=upper_bound_id, queue_id=queue_id)
+
+        return self.filter(
+            Q(
+                Q(
+                    queue_id=queue_id,
+                    lower_bound__timestamp_ms__lt=upper_bound.timestamp_ms,
+                    lower_bound__timestamp_ms__gt=lower_bound.timestamp_ms,
+                ) |
+                Q(
+                    queue_id=queue_id,
+                    upper_bound__timestamp_ms__gt=lower_bound.timestamp_ms,
+                    upper_bound__timestamp_ms__lt=upper_bound.timestamp_ms,
+                )
+            )
+        )
 
 
 @pgtrigger.register(
@@ -18,6 +100,8 @@ class QueueInterval(models.Model):
     None, it represents the beginning of the track. If the upper bound marker
     is None, it represents the end of the track.
     """
+    objects = QueueIntervalManager.from_queryset(QueueIntervalQuerySet)()
+
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     user = models.ForeignKey("users.User", on_delete=models.CASCADE)

--- a/jukebox_radio/streams/urls.py
+++ b/jukebox_radio/streams/urls.py
@@ -19,6 +19,9 @@ from jukebox_radio.streams.views.queue import (
     QueueDeleteView,
     QueueListView,
 )
+from jukebox_radio.streams.views.queue_interval import (
+    QueueIntervalCreateView,
+)
 
 
 app_name = "streams"
@@ -76,4 +79,11 @@ urlpatterns = [
     path("queue/create/", view=QueueCreateView.as_view(), name="queue-create"),
     path("queue/delete/", view=QueueDeleteView.as_view(), name="queue-delete"),
     path("queue/list/", view=QueueListView.as_view(), name="queue-list"),
+    # QueueInterval
+    # --------------------------------------------------------------------------
+    path(
+        "queue-interval/create/",
+        view=QueueIntervalCreateView.as_view(),
+        name="queue-interval-create",
+    ),
 ]

--- a/jukebox_radio/streams/views/queue_interval/__init__.py
+++ b/jukebox_radio/streams/views/queue_interval/__init__.py
@@ -1,0 +1,1 @@
+from .create_view import QueueIntervalCreateView

--- a/jukebox_radio/streams/views/queue_interval/create_view.py
+++ b/jukebox_radio/streams/views/queue_interval/create_view.py
@@ -1,0 +1,31 @@
+from django.apps import apps
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from jukebox_radio.core.base_view import BaseView
+
+
+class QueueIntervalCreateView(BaseView, LoginRequiredMixin):
+    def post(self, request, **kwargs):
+        """
+        Create a QueueInterval.
+        """
+        QueueInterval = apps.get_model("streams", "QueueInterval")
+
+        queue_uuid = request.POST.get("queueUuid")
+
+        lower_bound_marker_uuid = request.POST.get("lowerBoundMarkerUuid")
+        upper_bound_marker_uuid = request.POST.get("upperBoundMarkerUuid")
+
+        is_muted = request.POST.get("isMuted") == "true"
+        repeat_count = request.POST.get("repeatCount")
+
+        QueueInterval.objects.create(
+            user=request.user,
+            queue_id=queue_uuid,
+            lower_bound_id=lower_bound_marker_uuid,
+            upper_bound_id=upper_bound_marker_uuid,
+            is_muted=is_muted,
+            repeat_count=repeat_count,
+        )
+
+        return self.http_response_200()

--- a/jukebox_radio/streams/views/queue_interval/create_view.py
+++ b/jukebox_radio/streams/views/queue_interval/create_view.py
@@ -19,7 +19,7 @@ class QueueIntervalCreateView(BaseView, LoginRequiredMixin):
         is_muted = request.POST.get("isMuted") == "true"
         repeat_count = request.POST.get("repeatCount")
 
-        QueueInterval.objects.create(
+        QueueInterval.objects.create_queue_interval(
             user=request.user,
             queue_id=queue_uuid,
             lower_bound_id=lower_bound_marker_uuid,


### PR DESCRIPTION
**Previous PR**

https://github.com/0x213F/jukebox-radio-django/pull/7

**Next PR**

https://github.com/0x213F/jukebox-radio-django/pull/9

**Summary**

These 6 PRs implement the backend changes required for advanced queue playback functionality.

This new endpoint allows a user to create a queue interval.