### PR TITLE
API endpoint for deleting an interval

### DIFF
--- a/jukebox_radio/streams/models/queue_interval_model.py
+++ b/jukebox_radio/streams/models/queue_interval_model.py
@@ -6,6 +6,8 @@ from django.db.models import Q
 
 import pgtrigger
 
+from jukebox_radio.core import time as time_util
+
 
 class QueueIntervalManager(models.Manager):
     def serialize(self, queue_interval):
@@ -131,3 +133,7 @@ class QueueInterval(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     deleted_at = models.DateTimeField(null=True, blank=True)
+
+    def archive(self):
+        self.deleted_at = time_util.now()
+        self.save()

--- a/jukebox_radio/streams/urls.py
+++ b/jukebox_radio/streams/urls.py
@@ -21,6 +21,7 @@ from jukebox_radio.streams.views.queue import (
 )
 from jukebox_radio.streams.views.queue_interval import (
     QueueIntervalCreateView,
+    QueueIntervalDeleteView,
 )
 
 
@@ -85,5 +86,10 @@ urlpatterns = [
         "queue-interval/create/",
         view=QueueIntervalCreateView.as_view(),
         name="queue-interval-create",
+    ),
+    path(
+        "queue-interval/delete/",
+        view=QueueIntervalDeleteView.as_view(),
+        name="queue-interval-delete",
     ),
 ]

--- a/jukebox_radio/streams/views/queue_interval/__init__.py
+++ b/jukebox_radio/streams/views/queue_interval/__init__.py
@@ -1,1 +1,2 @@
 from .create_view import QueueIntervalCreateView
+from .delete_view import QueueIntervalDeleteView

--- a/jukebox_radio/streams/views/queue_interval/delete_view.py
+++ b/jukebox_radio/streams/views/queue_interval/delete_view.py
@@ -1,0 +1,19 @@
+from django.apps import apps
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from jukebox_radio.core.base_view import BaseView
+
+
+class QueueIntervalDeleteView(BaseView, LoginRequiredMixin):
+    def post(self, request, **kwargs):
+        """
+        Delete (archive) a QueueInterval.
+        """
+        QueueInterval = apps.get_model("streams", "QueueInterval")
+
+        queue_interval_uuid = request.POST.get("queueIntervalUuid")
+
+        queue_interval = QueueInterval.objects.get(uuid=queue_interval_uuid)
+        queue_interval.archive()
+
+        return self.http_response_200()


### PR DESCRIPTION
**Previous PR**

https://github.com/0x213F/jukebox-radio-django/pull/8

**Next PR**

_`None`_

**Summary**

These 6 PRs implement the backend changes required for advanced queue playback functionality.

This new endpoint allows a user to delete a queue interval.