### PR TITLE
API list markers

### DIFF
--- a/jukebox_radio/streams/models/queue_interval_model.py
+++ b/jukebox_radio/streams/models/queue_interval_model.py
@@ -99,8 +99,8 @@ class QueueIntervalQuerySet(models.QuerySet):
                 ) |
                 Q(
                     queue_id=queue_id,
-                    lower_bound=lower_bound,
-                    upper_bound=upper_bound,
+                    lower_bound__timestamp_ms=lower_bound.timestamp_ms,
+                    upper_bound__timestamp_ms=upper_bound.timestamp_ms,
                 )
             )
         )

--- a/jukebox_radio/streams/urls.py
+++ b/jukebox_radio/streams/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from jukebox_radio.streams.views.marker import (
     MarkerCreateView,
     MarkerDeleteView,
+    MarkerListView,
 )
 from jukebox_radio.streams.views.stream import (
     StreamGetView,
@@ -38,6 +39,11 @@ urlpatterns = [
         "marker/delete/",
         view=MarkerDeleteView.as_view(),
         name="marker-delete",
+    ),
+    path(
+        "marker/list/",
+        view=MarkerListView.as_view(),
+        name="marker-list",
     ),
     # Stream
     # --------------------------------------------------------------------------

--- a/jukebox_radio/streams/views/marker/__init__.py
+++ b/jukebox_radio/streams/views/marker/__init__.py
@@ -1,2 +1,3 @@
 from .create_view import MarkerCreateView
 from .delete_view import MarkerDeleteView
+from .list_view import MarkerListView

--- a/jukebox_radio/streams/views/marker/list_view.py
+++ b/jukebox_radio/streams/views/marker/list_view.py
@@ -7,7 +7,7 @@ from jukebox_radio.core.base_view import BaseView
 class MarkerListView(BaseView, LoginRequiredMixin):
     def get(self, request, **kwargs):
         """
-        Create a Marker.
+        List Markers.
         """
         Marker = apps.get_model("streams", "Marker")
 

--- a/jukebox_radio/streams/views/marker/list_view.py
+++ b/jukebox_radio/streams/views/marker/list_view.py
@@ -1,0 +1,28 @@
+from django.apps import apps
+from django.contrib.auth.mixins import LoginRequiredMixin
+
+from jukebox_radio.core.base_view import BaseView
+
+
+class MarkerListView(BaseView, LoginRequiredMixin):
+    def get(self, request, **kwargs):
+        """
+        Create a Marker.
+        """
+        Marker = apps.get_model("streams", "Marker")
+
+        track_uuid = request.POST.get("trackUuid")
+
+        marker_qs = Marker.objects.filter(
+            user=request.user,
+            track_id=track_uuid,
+            deleted_at__isnull=True,
+        )
+
+        markers = []
+        for marker in marker_qs:
+            markers.append(Marker.objects.serialize(marker))
+
+        return self.http_response_200({
+            "markers": markers,
+        })


### PR DESCRIPTION
**Summary**

Also a follow-up to the long chain of PRs (https://github.com/0x213F/jukebox-radio-django/pull/10)

This creates another endpoint which lists all markers given a track UUID. It only returns markers that the user has created.